### PR TITLE
Add initial Bluetooth pairing support (from g1ot).

### DIFF
--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
@@ -11,4 +11,8 @@ interface IG1Service {
     void disconnectGlasses(String id, @nullable OperationCallback callback);
     void displayTextPage(String id, in String[] page, @nullable OperationCallback callback);
     void stopDisplaying(String id, @nullable OperationCallback callback);
+    void connectGlasses();
+    void disconnectGlasses();
+    boolean isConnected();
+    void sendMessage(String msg);
 }

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -89,6 +89,20 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
         service?.disconnectGlasses(id, null)
     }
 
+    fun connectGlasses() {
+        service?.connectGlasses()
+    }
+
+    fun disconnectGlasses() {
+        service?.disconnectGlasses()
+    }
+
+    fun isConnected(): Boolean = service?.isConnected ?: false
+
+    fun sendMessage(message: String) {
+        service?.sendMessage(message)
+    }
+
     override suspend fun displayTextPage(id: String, page: List<String>) =
         suspendCoroutine<Boolean> { continuation ->
             service?.displayTextPage(

--- a/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
@@ -31,5 +31,17 @@ class Repository @Inject constructor(
     fun disconnectGlasses(id: String) =
         service.disconnect(id)
 
+    fun connectSelectedGlasses() =
+        service.connectGlasses()
+
+    fun disconnectGlasses() =
+        service.disconnectGlasses()
+
+    fun isConnected() =
+        service.isConnected()
+
+    fun sendMessage(message: String) =
+        service.sendMessage(message)
+
     private lateinit var service: G1ServiceManager
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -1,81 +1,169 @@
 package io.texne.g1.hub.ui
 
-import GlassesScreen
-import ScannerScreen
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import android.widget.Toast
 import androidx.hilt.navigation.compose.hiltViewModel
+import io.texne.g1.basis.client.G1ServiceCommon
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun ApplicationFrame() {
     val viewModel = hiltViewModel<ApplicationViewModel>()
-    val state = viewModel.state.collectAsState().value
+    val state by viewModel.state.collectAsState()
+    var selectedId by remember { mutableStateOf<String?>(null) }
+    var message by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is ApplicationViewModel.Event.ConnectionResult -> {
+                    val text = if (event.success) {
+                        "Connected to glasses"
+                    } else {
+                        "Failed to connect"
+                    }
+                    Toast.makeText(context, text, Toast.LENGTH_SHORT).show()
+                }
+                ApplicationViewModel.Event.Disconnected -> {
+                    Toast.makeText(context, "Disconnected", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(state.connectedGlasses?.id) {
+        selectedId = state.connectedGlasses?.id
+    }
 
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Header()
+        Text(
+            text = "Moncchichi Hub",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(text = "Manage Even Realities G1 glasses over Bluetooth")
 
-        val connectedGlasses = state?.connectedGlasses
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Button(onClick = { viewModel.scan() }) {
+                Text(if (state.scanning) "Scanning..." else "Scan for devices")
+            }
+            if (state.connectedGlasses != null) {
+                Button(onClick = { viewModel.disconnect(state.connectedGlasses.id) }) {
+                    Text("Disconnect")
+                }
+            } else {
+                Button(onClick = {
+                    val target = selectedId ?: state.nearbyGlasses?.firstOrNull()?.id
+                    if (target != null) {
+                        viewModel.connect(target)
+                    } else {
+                        Toast.makeText(context, "Select a device first", Toast.LENGTH_SHORT).show()
+                    }
+                }) {
+                    Text("Connect")
+                }
+            }
+        }
 
-        if (connectedGlasses != null) {
-            GlassesScreen(
-                connectedGlasses,
-                { viewModel.disconnect(connectedGlasses.id) }
+        val devices = state.nearbyGlasses ?: emptyList()
+        if (devices.isEmpty()) {
+            Text(
+                text = if (state.scanning) "Scanning for glasses..." else "No glasses found",
+                modifier = Modifier.padding(vertical = 8.dp),
             )
         } else {
-            ScannerScreen(
-                scanning = state?.scanning == true,
-                error = state?.error == true,
-                nearbyGlasses = state?.nearbyGlasses,
-                scan = { viewModel.scan() },
-                connect = { viewModel.connect(it) },
-            )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(devices) { glasses ->
+                    DeviceRow(
+                        glasses = glasses,
+                        selected = glasses.id == selectedId,
+                        onClick = { selectedId = glasses.id },
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = message,
+            onValueChange = { message = it },
+            label = { Text("Message to send") },
+            singleLine = false,
+            maxLines = 3,
+        )
+        Button(
+            enabled = message.isNotBlank() && state.connectedGlasses != null,
+            onClick = {
+                viewModel.sendMessage(message)
+                Toast.makeText(context, "Message sent", Toast.LENGTH_SHORT).show()
+            },
+        ) {
+            Text("Send")
         }
     }
 }
 
 @Composable
-fun Header() {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(128.dp),
-        contentAlignment = Alignment.Center
+private fun DeviceRow(
+    glasses: G1ServiceCommon.Glasses,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        border = if (selected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
-        Column(
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy((-8).dp)
-        ) {
-            Row(
-            ) {
-                Image(
-                    painter = painterResource(io.texne.g1.basis.service.R.mipmap.ic_service_foreground),
-                    contentDescription = "G1 Hub Logo",
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.height(40.dp).width(32.dp)
-                )
-                Text("G1", fontSize = 32.sp, fontWeight = FontWeight.Black, color = Color.Gray, fontStyle = FontStyle.Italic)
-                Text("Hub", fontSize = 32.sp, fontWeight = FontWeight.Bold)
-            }
-            Text("A hub for Basis applications", fontSize = 11.sp)
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = glasses.name, style = MaterialTheme.typography.titleMedium)
+            Text(text = glasses.id, style = MaterialTheme.typography.bodySmall)
         }
     }
 }

--- a/service/src/main/java/com/loopermallee/moncchichi/bluetooth/BluetoothConstants.kt
+++ b/service/src/main/java/com/loopermallee/moncchichi/bluetooth/BluetoothConstants.kt
@@ -1,0 +1,19 @@
+package com.loopermallee.moncchichi.bluetooth
+
+import java.util.UUID
+
+internal object BluetoothConstants {
+    const val DEVICE_PREFIX = "Even G1_"
+
+    val UART_SERVICE_UUID: UUID = UUID.fromString("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+    val UART_WRITE_CHARACTERISTIC_UUID: UUID = UUID.fromString("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+    val UART_READ_CHARACTERISTIC_UUID: UUID = UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    const val OPCODE_CLEAR_SCREEN: Byte = 0x18
+    const val OPCODE_HEARTBEAT: Byte = 0x25
+    const val OPCODE_SEND_TEXT: Byte = 0x4E
+
+    const val MAX_CHUNK_SIZE = 20
+    const val HEARTBEAT_INTERVAL_SECONDS = 28L
+    const val HEARTBEAT_TIMEOUT_SECONDS = 32L
+}

--- a/service/src/main/java/com/loopermallee/moncchichi/bluetooth/BluetoothManager.kt
+++ b/service/src/main/java/com/loopermallee/moncchichi/bluetooth/BluetoothManager.kt
@@ -1,0 +1,131 @@
+package com.loopermallee.moncchichi.bluetooth
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager as SystemBluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanResult
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+private const val TAG = "BluetoothManager"
+
+internal class BluetoothManager(
+    context: Context,
+    private val scope: CoroutineScope,
+) {
+    private val systemBluetoothManager =
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as? SystemBluetoothManager
+    private val bluetoothAdapter: BluetoothAdapter? = systemBluetoothManager?.adapter
+    private val scanner: BluetoothLeScanner? = bluetoothAdapter?.bluetoothLeScanner
+    private val deviceManager = DeviceManager(context, scope)
+
+    private val writableDevices = MutableStateFlow<Map<String, ScanResult>>(emptyMap())
+    private val readableDevices = MutableStateFlow<List<ScanResult>>(emptyList())
+    val devices: StateFlow<List<ScanResult>> = readableDevices.asStateFlow()
+
+    init {
+        scope.launch {
+            writableDevices.collect { map ->
+                readableDevices.value = map.values.sortedBy { it.device.name ?: it.device.address }
+            }
+        }
+    }
+
+    private val writableSelectedAddress = MutableStateFlow<String?>(null)
+    val selectedAddress: StateFlow<String?> = writableSelectedAddress.asStateFlow()
+
+    val connectionState = deviceManager.connectionState
+
+    private var scanCallback: ScanCallback? = null
+    private var scanJob: Job? = null
+
+    fun startScan() {
+        if (scanCallback != null) {
+            return
+        }
+        val callback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                if (!result.device.name.isNullOrEmpty() &&
+                    result.device.name.startsWith(BluetoothConstants.DEVICE_PREFIX)
+                ) {
+                    writableDevices.value = writableDevices.value.plus(result.device.address to result)
+                }
+            }
+
+            override fun onScanFailed(errorCode: Int) {
+                Log.w(TAG, "startScan: failed with errorCode=$errorCode")
+            }
+        }
+        scanCallback = callback
+        @SuppressLint("MissingPermission")
+        val started = try {
+            scanner?.startScan(callback)
+            true
+        } catch (t: Throwable) {
+            Log.e(TAG, "startScan: failed", t)
+            false
+        }
+        if (!started) {
+            scanCallback = null
+            return
+        }
+        scanJob = scope.launch {
+            kotlinx.coroutines.delay(15_000)
+            stopScan()
+        }
+    }
+
+    fun stopScan() {
+        val callback = scanCallback ?: return
+        @SuppressLint("MissingPermission")
+        try {
+            scanner?.stopScan(callback)
+        } catch (t: Throwable) {
+            Log.e(TAG, "stopScan: failed", t)
+        }
+        scanCallback = null
+        scanJob?.cancel()
+        scanJob = null
+    }
+
+    @SuppressLint("MissingPermission")
+    fun connect(address: String): Boolean {
+        val device = bluetoothAdapter?.getRemoteDevice(address)
+        if (device == null) {
+            Log.w(TAG, "connect: no device for $address")
+            return false
+        }
+        writableSelectedAddress.value = address
+        deviceManager.connect(device)
+        return true
+    }
+
+    fun disconnect() {
+        writableSelectedAddress.value = null
+        deviceManager.disconnect()
+    }
+
+    fun isConnected(): Boolean = deviceManager.isConnected()
+
+    suspend fun sendMessage(message: String): Boolean {
+        return deviceManager.sendText(message)
+    }
+
+    suspend fun clearScreen(): Boolean {
+        return deviceManager.clearScreen()
+    }
+
+    fun selectedDevice(): BluetoothDevice? {
+        val address = writableSelectedAddress.value ?: return null
+        return bluetoothAdapter?.getRemoteDevice(address)
+    }
+}

--- a/service/src/main/java/com/loopermallee/moncchichi/bluetooth/DeviceManager.kt
+++ b/service/src/main/java/com/loopermallee/moncchichi/bluetooth/DeviceManager.kt
@@ -1,0 +1,228 @@
+package com.loopermallee.moncchichi.bluetooth
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.min
+
+private const val TAG = "DeviceManager"
+
+internal class DeviceManager(
+    private val context: Context,
+    private val scope: CoroutineScope,
+) {
+    enum class ConnectionState {
+        DISCONNECTED,
+        CONNECTING,
+        CONNECTED,
+        DISCONNECTING,
+        ERROR,
+    }
+
+    private val writableConnectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+    val connectionState = writableConnectionState.asStateFlow()
+
+    private val writableIncoming = MutableSharedFlow<ByteArray>(extraBufferCapacity = 32)
+    val incoming = writableIncoming.asSharedFlow()
+
+    private val writeMutex = Mutex()
+
+    private var bluetoothGatt: BluetoothGatt? = null
+    private var writeCharacteristic: BluetoothGattCharacteristic? = null
+    private var readCharacteristic: BluetoothGattCharacteristic? = null
+
+    private var heartbeatJob: Job? = null
+    private var heartbeatTimeoutJob: Job? = null
+    private val awaitingAck = AtomicBoolean(false)
+    private var lastAckTimestamp: Long = 0L
+
+    @SuppressLint("MissingPermission")
+    fun connect(device: BluetoothDevice) {
+        if (writableConnectionState.value == ConnectionState.CONNECTING ||
+            writableConnectionState.value == ConnectionState.CONNECTED
+        ) {
+            Log.d(TAG, "connect: already connected or connecting")
+            return
+        }
+        writableConnectionState.value = ConnectionState.CONNECTING
+        bluetoothGatt = device.connectGatt(context, false, object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+                when (newState) {
+                    BluetoothProfile.STATE_CONNECTED -> {
+                        Log.d(TAG, "onConnectionStateChange: connected")
+                        writableConnectionState.value = ConnectionState.CONNECTED
+                        gatt.discoverServices()
+                    }
+                    BluetoothProfile.STATE_CONNECTING -> {
+                        writableConnectionState.value = ConnectionState.CONNECTING
+                    }
+                    BluetoothProfile.STATE_DISCONNECTING -> {
+                        writableConnectionState.value = ConnectionState.DISCONNECTING
+                    }
+                    BluetoothProfile.STATE_DISCONNECTED -> {
+                        Log.d(TAG, "onConnectionStateChange: disconnected")
+                        stopHeartbeat()
+                        clearConnection()
+                        writableConnectionState.value = ConnectionState.DISCONNECTED
+                    }
+                }
+            }
+
+            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                if (status != BluetoothGatt.GATT_SUCCESS) {
+                    Log.w(TAG, "onServicesDiscovered: failure status=$status")
+                    writableConnectionState.value = ConnectionState.ERROR
+                    return
+                }
+                val uartService = gatt.getService(BluetoothConstants.UART_SERVICE_UUID)
+                if (uartService == null) {
+                    Log.w(TAG, "UART service not available on device")
+                    writableConnectionState.value = ConnectionState.ERROR
+                    return
+                }
+                initializeCharacteristics(gatt, uartService)
+            }
+
+            override fun onCharacteristicChanged(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+            ) {
+                if (characteristic.uuid == BluetoothConstants.UART_READ_CHARACTERISTIC_UUID) {
+                    val payload = characteristic.value
+                    writableIncoming.tryEmit(payload)
+                    awaitingAck.set(false)
+                    lastAckTimestamp = SystemClock.elapsedRealtime()
+                }
+            }
+        })
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initializeCharacteristics(gatt: BluetoothGatt, service: BluetoothGattService) {
+        writeCharacteristic = service.getCharacteristic(BluetoothConstants.UART_WRITE_CHARACTERISTIC_UUID)
+        readCharacteristic = service.getCharacteristic(BluetoothConstants.UART_READ_CHARACTERISTIC_UUID)
+        if (writeCharacteristic == null || readCharacteristic == null) {
+            Log.w(TAG, "Required UART characteristics not found")
+            writableConnectionState.value = ConnectionState.ERROR
+            return
+        }
+        val notified = gatt.setCharacteristicNotification(readCharacteristic, true)
+        if (!notified) {
+            Log.w(TAG, "Unable to enable notifications")
+            writableConnectionState.value = ConnectionState.ERROR
+            return
+        }
+        bluetoothGatt = gatt
+        startHeartbeat()
+    }
+
+    private fun startHeartbeat() {
+        stopHeartbeat()
+        lastAckTimestamp = SystemClock.elapsedRealtime()
+        heartbeatJob = scope.launch {
+            while (true) {
+                val success = sendCommand(byteArrayOf(BluetoothConstants.OPCODE_HEARTBEAT))
+                if (success) {
+                    awaitingAck.set(true)
+                    monitorHeartbeatTimeout()
+                }
+                delay(BluetoothConstants.HEARTBEAT_INTERVAL_SECONDS * 1000)
+            }
+        }
+    }
+
+    private fun monitorHeartbeatTimeout() {
+        heartbeatTimeoutJob?.cancel()
+        heartbeatTimeoutJob = scope.launch {
+            delay(BluetoothConstants.HEARTBEAT_TIMEOUT_SECONDS * 1000)
+            val elapsed = SystemClock.elapsedRealtime() - lastAckTimestamp
+            if (awaitingAck.get() && elapsed >= BluetoothConstants.HEARTBEAT_TIMEOUT_SECONDS * 1000) {
+                Log.w(TAG, "Heartbeat timeout reached, disconnecting")
+                disconnect()
+            }
+        }
+    }
+
+    private fun stopHeartbeat() {
+        heartbeatJob?.cancel()
+        heartbeatTimeoutJob?.cancel()
+        awaitingAck.set(false)
+    }
+
+    @SuppressLint("MissingPermission")
+    fun disconnect() {
+        stopHeartbeat()
+        writableConnectionState.value = ConnectionState.DISCONNECTING
+        bluetoothGatt?.disconnect()
+        bluetoothGatt?.close()
+        clearConnection()
+        writableConnectionState.value = ConnectionState.DISCONNECTED
+    }
+
+    private fun clearConnection() {
+        bluetoothGatt = null
+        writeCharacteristic = null
+        readCharacteristic = null
+    }
+
+    suspend fun sendText(message: String): Boolean {
+        val payload = message.encodeToByteArray()
+        if (payload.isEmpty()) {
+            return sendCommand(byteArrayOf(BluetoothConstants.OPCODE_SEND_TEXT))
+        }
+        var index = 0
+        var success = true
+        while (index < payload.size && success) {
+            val remaining = payload.size - index
+            val chunkSize = min(BluetoothConstants.MAX_CHUNK_SIZE - 1, remaining)
+            val chunk = ByteArray(chunkSize + 1)
+            chunk[0] = BluetoothConstants.OPCODE_SEND_TEXT
+            System.arraycopy(payload, index, chunk, 1, chunkSize)
+            index += chunkSize
+            success = sendCommand(chunk)
+        }
+        return success
+    }
+
+    suspend fun clearScreen(): Boolean = sendCommand(byteArrayOf(BluetoothConstants.OPCODE_CLEAR_SCREEN))
+
+    private suspend fun sendCommand(payload: ByteArray): Boolean {
+        return writeMutex.withLock {
+            val gatt = bluetoothGatt ?: return@withLock false
+            val characteristic = writeCharacteristic ?: return@withLock false
+            characteristic.value = payload
+            val success = try {
+                @SuppressLint("MissingPermission")
+                gatt.writeCharacteristic(characteristic)
+            } catch (t: Throwable) {
+                Log.e(TAG, "sendCommand: failed", t)
+                false
+            }
+            if (!success) {
+                Log.w(TAG, "sendCommand: write failed")
+            }
+            success
+        }
+    }
+
+    fun isConnected(): Boolean =
+        writableConnectionState.value == ConnectionState.CONNECTED
+}

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -11,359 +11,110 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.loopermallee.moncchichi.bluetooth.BluetoothManager
+import com.loopermallee.moncchichi.bluetooth.DeviceManager
 import com.nabinbhandari.android.permissions.PermissionHandler
 import com.nabinbhandari.android.permissions.Permissions
-import io.texne.g1.basis.core.G1
 import io.texne.g1.basis.service.protocol.G1Glasses
-import io.texne.g1.basis.service.protocol.ObserveStateCallback
-import io.texne.g1.basis.service.protocol.OperationCallback
 import io.texne.g1.basis.service.protocol.G1ServiceState
 import io.texne.g1.basis.service.protocol.IG1Service
 import io.texne.g1.basis.service.protocol.IG1ServiceClient
+import io.texne.g1.basis.service.protocol.ObserveStateCallback
+import io.texne.g1.basis.service.protocol.OperationCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
-//
-
-private fun G1.ConnectionState.toInt(): Int =
-    when(this) {
-        G1.ConnectionState.UNINITIALIZED -> G1Glasses.UNINITIALIZED
-        G1.ConnectionState.DISCONNECTED -> G1Glasses.DISCONNECTED
-        G1.ConnectionState.CONNECTING -> G1Glasses.CONNECTING
-        G1.ConnectionState.CONNECTED -> G1Glasses.CONNECTED
-        G1.ConnectionState.DISCONNECTING -> G1Glasses.DISCONNECTING
-        G1.ConnectionState.ERROR -> G1Glasses.ERROR
+private fun DeviceManager.ConnectionState.toInt(): Int =
+    when (this) {
+        DeviceManager.ConnectionState.DISCONNECTED -> G1Glasses.DISCONNECTED
+        DeviceManager.ConnectionState.CONNECTING -> G1Glasses.CONNECTING
+        DeviceManager.ConnectionState.CONNECTED -> G1Glasses.CONNECTED
+        DeviceManager.ConnectionState.DISCONNECTING -> G1Glasses.DISCONNECTING
+        DeviceManager.ConnectionState.ERROR -> G1Glasses.ERROR
     }
 
-private fun G1Service.ServiceStatus.toInt(): Int =
-    when(this) {
-        G1Service.ServiceStatus.READY -> G1ServiceState.READY
-        G1Service.ServiceStatus.LOOKING -> G1ServiceState.LOOKING
-        G1Service.ServiceStatus.LOOKED -> G1ServiceState.LOOKED
-        G1Service.ServiceStatus.ERROR -> G1ServiceState.ERROR
+private fun ServiceStatus.toInt(): Int =
+    when (this) {
+        ServiceStatus.READY -> G1ServiceState.READY
+        ServiceStatus.LOOKING -> G1ServiceState.LOOKING
+        ServiceStatus.LOOKED -> G1ServiceState.LOOKED
+        ServiceStatus.ERROR -> G1ServiceState.ERROR
     }
 
-private fun G1Service.InternalGlasses.toGlasses(): G1Glasses {
-    val glasses = G1Glasses()
-    glasses.id = this.g1.id
-    glasses.name = this.g1.name
-    glasses.connectionState = this.connectionState.toInt()
-    glasses.batteryPercentage = this.batteryPercentage ?: -1
-    return glasses
+private fun InternalDevice.toGlasses(): G1Glasses = G1Glasses().apply {
+    id = address
+    name = this@toGlasses.name
+    connectionState = connectionState.toInt()
+    batteryPercentage = -1
 }
 
-private fun G1Service.InternalState.toState(): G1ServiceState {
-    val state = G1ServiceState()
-    state.status = this.status.toInt()
-    state.glasses = this.glasses.values.map { it -> it.toGlasses() }.toTypedArray()
-    return state
+private fun InternalState.toState(): G1ServiceState = G1ServiceState().apply {
+    status = this@toState.status.toInt()
+    glasses = this@toState.devices.values.map { it.toGlasses() }.toTypedArray()
 }
 
-//
+enum class ServiceStatus {
+    READY,
+    LOOKING,
+    LOOKED,
+    ERROR,
+}
 
-class G1Service: Service() {
+internal data class InternalDevice(
+    val address: String,
+    val name: String,
+    val connectionState: DeviceManager.ConnectionState,
+)
 
-    enum class ServiceStatus {
-        READY,
-        LOOKING,
-        LOOKED,
-        ERROR
-    }
+internal data class InternalState(
+    val status: ServiceStatus = ServiceStatus.READY,
+    val devices: Map<String, InternalDevice> = emptyMap(),
+    val selectedAddress: String? = null,
+)
 
-    // internal state ------------------------------------------------------------------------------
+class G1Service : Service() {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val bluetoothManager by lazy { BluetoothManager(this, coroutineScope) }
 
     val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "savedState")
 
-    internal data class InternalGlasses(
-        val connectionState: G1.ConnectionState,
-        val batteryPercentage: Int?,
-        val g1: G1
-    )
-    internal data class InternalState(
-        val status: ServiceStatus = ServiceStatus.READY,
-        val glasses: Map<String, InternalGlasses> = mapOf()
-    )
-    private val state = MutableStateFlow<InternalState>(InternalState())
-
-    // client-service interface --------------------------------------------------------------------
-
-    private fun commonObserveState(callback: ObserveStateCallback?) {
-        if(callback != null) {
-            coroutineScope.launch {
-                state.collect {
-                    callback.onStateChange(it.toState())
-                }
-            }
-        }
-    }
-
-    private fun commonDisplayTextPage(
-        id: String?,
-        page: Array<out String?>?,
-        callback: OperationCallback?
-    ) {
-        if(id != null && page != null) {
-            val glasses = state.value.glasses.get(id)
-            if (glasses != null) {
-                coroutineScope.launch {
-                    val result = glasses.g1.displayTextPage(page.filterNotNull())
-                    callback?.onResult(result)
-                }
-            }
-        }
-    }
-
-    private fun commonStopDisplaying(id: String?, callback: OperationCallback?) {
-        if(id != null) {
-            val glasses = state.value.glasses.get(id)
-            if (glasses != null) {
-                coroutineScope.launch {
-                    val result = glasses.g1.stopDisplaying()
-                    callback?.onResult(result)
-                }
-            }
-        }
-    }
-
-    private val clientBinder = object : IG1ServiceClient.Stub() {
-        override fun observeState(callback: ObserveStateCallback?) = commonObserveState(callback)
-        override fun displayTextPage(
-            id: String?,
-            page: Array<out String?>?,
-            callback: OperationCallback?
-        ) = commonDisplayTextPage(id, page, callback)
-        override fun stopDisplaying(
-            id: String?,
-            callback: OperationCallback?
-        ) = commonStopDisplaying(id, callback)
-    }
-
-    private val binder = object : IG1Service.Stub() {
-
-        override fun observeState(callback: ObserveStateCallback?) = commonObserveState(callback)
-
-        override fun lookForGlasses() {
-            if(state.value.status == ServiceStatus.LOOKING) {
-                return
-            }
-            withPermissions {
-                coroutineScope.launch {
-                    // clear all glasses except connected
-                    state.value = state.value.copy(
-                        status = ServiceStatus.LOOKING,
-                        glasses = state.value.glasses.values
-                            .filter { it.connectionState == G1.ConnectionState.CONNECTED }
-                            .associate { Pair(it.g1.id, it) }
-                    )
-
-                    // make sure last connected id makes sense, fix if it doesn't for some reason
-                    val LAST_CONNECTED_ID = stringPreferencesKey("last_connected_id")
-                    var lastConnectedId = dataStore.data.map { preferences -> preferences[LAST_CONNECTED_ID] }.first()
-                    val connectedId = state.value.glasses.values.find { it.connectionState == G1.ConnectionState.CONNECTED }?.g1?.id
-                    if(connectedId != null && lastConnectedId != connectedId) {
-                        dataStore.edit { settings ->
-                            settings[LAST_CONNECTED_ID] = connectedId
-                        }
-                        lastConnectedId = connectedId
-                    }
-
-                    G1.find(15.toDuration(DurationUnit.SECONDS)).collect { found ->
-                        if(found != null) {
-                            Log.d("G1Service", "SCANNING FOUND = ${found}")
-
-                            // add to glasses state if not already there
-                            if(state.value.glasses.values.find { it.g1.id == found.id } == null) {
-                                state.value = state.value.copy(
-                                    glasses = state.value.glasses.plus(
-                                        Pair(found.id, InternalGlasses(found.state.value.connectionState, found.state.value.batteryPercentage, found))
-                                    )
-                                )
-                                coroutineScope.launch {
-                                    found.state.collect { glassesState ->
-                                        Log.d(
-                                            "G1Service",
-                                            "GLASSES_STATE ${found.name} (${found.id}) = ${glassesState}"
-                                        )
-                                        state.value =
-                                            state.value.copy(glasses = state.value.glasses.entries.associate {
-                                                if (it.key == found.id) {
-                                                    Pair(
-                                                        it.key,
-                                                        it.value.copy(
-                                                            connectionState = glassesState.connectionState,
-                                                            batteryPercentage = glassesState.batteryPercentage,
-                                                            g1 = it.value.g1
-                                                        )
-                                                    )
-                                                } else {
-                                                    Pair(
-                                                        it.key,
-                                                        it.value
-                                                    )
-                                                }
-                                            })
-                                    }
-                                }
-
-                                // if this is the pair we were connected to before, reconnect
-                                if(lastConnectedId == found.id) {
-                                    connectGlasses(found.id, null)
-                                }
-                            }
-                        } else {
-                            state.value = state.value.copy(
-                                status = ServiceStatus.LOOKED,
-                                glasses = state.value.glasses,
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        override fun connectGlasses(id: String?, callback: OperationCallback?) {
-            if(id != null) {
-                val glasses = state.value.glasses.get(id)
-                if (glasses != null) {
-                    coroutineScope.launch {
-                        val result = glasses.g1.connect(this@G1Service, coroutineScope)
-                        if(result == true) {
-                            val LAST_CONNECTED_ID = stringPreferencesKey("last_connected_id")
-                            dataStore.edit { settings ->
-                                settings[LAST_CONNECTED_ID] = id
-                            }
-                        }
-                        callback?.onResult(result)
-                    }
-                } else {
-                    callback?.onResult(false)
-                }
-            } else {
-                callback?.onResult(false)
-            }
-        }
-
-        override fun disconnectGlasses(id: String?, callback: OperationCallback?) {
-            if(id != null) {
-                val glasses = state.value.glasses.get(id)
-                if (glasses != null) {
-                    coroutineScope.launch {
-                        glasses.g1.disconnect()
-                        val LAST_CONNECTED_ID = stringPreferencesKey("last_connected_id")
-                        dataStore.edit { settings ->
-                            settings.remove(LAST_CONNECTED_ID)
-                        }
-                        callback?.onResult(true)
-                    }
-                } else {
-                    callback?.onResult(false)
-                }
-            } else {
-                callback?.onResult(false)
-            }
-        }
-
-        override fun displayTextPage(
-            id: String?,
-            page: Array<out String?>?,
-            callback: OperationCallback?
-        ) = commonDisplayTextPage(id, page, callback)
-
-        override fun stopDisplaying(id: String?, callback: OperationCallback?) =
-            commonStopDisplaying(id, callback)
-    }
-
-    // infrastructure ------------------------------------------------------------------------------
-
-    private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    // permissions infrastructure ------------------------------------------------------------------
-
-    private fun withPermissions(block: () -> Unit) {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            Permissions.check(this@G1Service,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) arrayOf(
-                    Manifest.permission.BLUETOOTH_CONNECT,
-                    Manifest.permission.BLUETOOTH_SCAN,
-                    Manifest.permission.POST_NOTIFICATIONS
-                ) else arrayOf(
-                    Manifest.permission.BLUETOOTH_CONNECT,
-                    Manifest.permission.BLUETOOTH_SCAN,
-                ),
-                "Please provide the permissions so the service can interact with the G1 G1Glasses",
-                Permissions.Options().setCreateNewTask(true),
-                object: PermissionHandler() {
-                    override fun onGranted() {
-                        block()
-                    }
-                })
-        } else {
-            block()
-        }
-    }
-
-    // internal service mechanism ------------------------------------------------------------------
+    private val state: MutableStateFlow<InternalState> = MutableStateFlow(InternalState())
 
     override fun onCreate() {
         super.onCreate()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            withPermissions {
-                val G1_SERVICE_NOTIFICATION_CHANNEL_ID: String = "0xC0FFEE"
-                val G1_SERVICE_NOTIFICATION_ID: Int = 0xC0FFEE
-
-                val notificationChannel = NotificationChannel(
-                    G1_SERVICE_NOTIFICATION_CHANNEL_ID,
-                    getString(R.string.notification_channel_name),
-                    NotificationManager.IMPORTANCE_DEFAULT
-                )
-                notificationChannel.description =
-                    getString(R.string.notification_channel_description)
-                val notificationManager =
-                    getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-                notificationManager.createNotificationChannel(notificationChannel)
-
-                val notification = Notification.Builder(this, G1_SERVICE_NOTIFICATION_CHANNEL_ID)
-                    .setSmallIcon(R.mipmap.ic_service_foreground)
-                    .setContentTitle(getString(R.string.notification_channel_name))
-                    .setContentText(getString(R.string.notification_text))
-                    .setContentIntent(
-                        PendingIntent.getActivity(
-                            this, 0, Intent(this, G1Service::class.java),
-                            PendingIntent.FLAG_IMMUTABLE
+            withPermissions { ensureForegroundNotification() }
+        }
+        observeBluetooth()
+        coroutineScope.launch {
+            bluetoothManager.devices.collectLatest { results ->
+                state.value = state.value.copy(
+                    status = if (results.isEmpty()) ServiceStatus.READY else ServiceStatus.LOOKED,
+                    devices = results.associate { result ->
+                        result.device.address to InternalDevice(
+                            address = result.device.address,
+                            name = result.device.name ?: result.device.address,
+                            connectionState = if (bluetoothManager.selectedAddress.value == result.device.address &&
+                                bluetoothManager.isConnected()
+                            ) DeviceManager.ConnectionState.CONNECTED else DeviceManager.ConnectionState.DISCONNECTED,
                         )
-                    )
-                    .build()
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    startForeground(
-                        G1_SERVICE_NOTIFICATION_ID,
-                        notification,
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-                    )
-                } else {
-                    startForeground(G1_SERVICE_NOTIFICATION_ID, notification)
-                }
+                    },
+                )
             }
         }
-        binder.lookForGlasses()
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        return START_STICKY
-    }
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
 
     override fun onBind(intent: Intent?): IBinder? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -371,8 +122,7 @@ class G1Service: Service() {
         } else {
             applicationContext.startService(Intent(applicationContext, G1Service::class.java))
         }
-
-        return when(intent?.action) {
+        return when (intent?.action) {
             "io.texne.g1.basis.service.protocol.IG1Service" -> binder
             "io.texne.g1.basis.service.protocol.IG1ServiceClient" -> clientBinder
             else -> null
@@ -380,12 +130,191 @@ class G1Service: Service() {
     }
 
     override fun onDestroy() {
-        // disconnect any connected devices
+        coroutineScope.launch { bluetoothManager.disconnect() }
+        super.onDestroy()
+    }
+
+    private fun observeBluetooth() {
         coroutineScope.launch {
-            state.value.glasses.values.filter { it.connectionState == G1.ConnectionState.CONNECTED }.forEach {
-                it.g1.disconnect()
+            bluetoothManager.connectionState.collectLatest { connection ->
+                val address = bluetoothManager.selectedAddress.value
+                state.value = state.value.copy(
+                    devices = state.value.devices.mapValues { entry ->
+                        if (entry.key == address) {
+                            entry.value.copy(connectionState = connection)
+                        } else {
+                            entry.value.copy(connectionState = DeviceManager.ConnectionState.DISCONNECTED)
+                        }
+                    },
+                    selectedAddress = address,
+                )
             }
         }
-        onDestroy()
+    }
+
+    private val clientBinder = object : IG1ServiceClient.Stub() {
+        override fun observeState(callback: ObserveStateCallback?) = commonObserveState(callback)
+        override fun displayTextPage(id: String?, page: Array<out String?>?, callback: OperationCallback?) =
+            commonDisplayTextPage(page, callback)
+        override fun stopDisplaying(id: String?, callback: OperationCallback?) =
+            commonStopDisplaying(callback)
+    }
+
+    private val binder = object : IG1Service.Stub() {
+        override fun observeState(callback: ObserveStateCallback?) = commonObserveState(callback)
+
+        override fun lookForGlasses() {
+            if (state.value.status == ServiceStatus.LOOKING) {
+                return
+            }
+            withPermissions {
+                state.value = state.value.copy(status = ServiceStatus.LOOKING)
+                bluetoothManager.startScan()
+            }
+        }
+
+        override fun connectGlasses(id: String?, callback: OperationCallback?) {
+            val address = id ?: state.value.selectedAddress
+            if (address == null) {
+                callback?.onResult(false)
+                return
+            }
+            withPermissions {
+                val result = bluetoothManager.connect(address)
+                if (!result) {
+                    callback?.onResult(false)
+                } else {
+                    coroutineScope.launch {
+                        val LAST_CONNECTED_ID = androidx.datastore.preferences.core.stringPreferencesKey("last_connected_id")
+                        applicationContext.dataStore.edit { prefs ->
+                            prefs[LAST_CONNECTED_ID] = address
+                        }
+                    }
+                    callback?.onResult(true)
+                }
+            }
+        }
+
+        override fun disconnectGlasses(id: String?, callback: OperationCallback?) {
+            bluetoothManager.disconnect()
+            callback?.onResult(true)
+        }
+
+        override fun displayTextPage(id: String?, page: Array<out String?>?, callback: OperationCallback?) =
+            commonDisplayTextPage(page, callback)
+
+        override fun stopDisplaying(id: String?, callback: OperationCallback?) =
+            commonStopDisplaying(callback)
+
+        override fun connectGlasses() {
+            val preferred = state.value.selectedAddress ?: state.value.devices.keys.firstOrNull()
+            if (preferred != null) {
+                connectGlasses(preferred, null)
+            }
+        }
+
+        override fun disconnectGlasses() {
+            bluetoothManager.disconnect()
+        }
+
+        override fun isConnected(): Boolean = bluetoothManager.isConnected()
+
+        override fun sendMessage(msg: String?) {
+            if (msg == null) return
+            coroutineScope.launch { bluetoothManager.sendMessage(msg) }
+        }
+    }
+
+    private fun commonObserveState(callback: ObserveStateCallback?) {
+        if (callback == null) return
+        coroutineScope.launch {
+            state.collectLatest { callback.onStateChange(it.toState()) }
+        }
+    }
+
+    private fun commonDisplayTextPage(page: Array<out String?>?, callback: OperationCallback?) {
+        if (page.isNullOrEmpty()) {
+            callback?.onResult(false)
+            return
+        }
+        val message = page.filterNotNull().joinToString("\n")
+        coroutineScope.launch {
+            val result = bluetoothManager.sendMessage(message)
+            callback?.onResult(result)
+        }
+    }
+
+    private fun commonStopDisplaying(callback: OperationCallback?) {
+        coroutineScope.launch {
+            val result = bluetoothManager.clearScreen()
+            callback?.onResult(result)
+        }
+    }
+
+    private fun ensureForegroundNotification() {
+        val channelId = "0xC0FFEE"
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val notificationChannel = NotificationChannel(
+            channelId,
+            getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = getString(R.string.notification_channel_description)
+        }
+        notificationManager.createNotificationChannel(notificationChannel)
+
+        val notification = Notification.Builder(this, channelId)
+            .setSmallIcon(R.mipmap.ic_service_foreground)
+            .setContentTitle(getString(R.string.notification_channel_name))
+            .setContentText(getString(R.string.notification_text))
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    Intent(this, G1Service::class.java),
+                    PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                0xC0FFEE,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            )
+        } else {
+            startForeground(0xC0FFEE, notification)
+        }
+    }
+
+    private fun withPermissions(block: () -> Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                arrayOf(
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.BLUETOOTH_SCAN,
+                    Manifest.permission.POST_NOTIFICATIONS,
+                )
+            } else {
+                arrayOf(
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.BLUETOOTH_SCAN,
+                )
+            }
+            Permissions.check(
+                this@G1Service,
+                permissions,
+                "Please provide the permissions so the service can interact with the G1 glasses",
+                Permissions.Options().setCreateNewTask(true),
+                object : PermissionHandler() {
+                    override fun onGranted() {
+                        block()
+                    }
+                },
+            )
+        } else {
+            block()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a BluetoothManager/DeviceManager stack ported from g1ot for G1 BLE communication
- extend the service binder API and Hub service implementation to drive pairing, heartbeats, and messaging
- refresh the Hub UI with scan/connect controls, a message sender, and toast feedback

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6abe3a9f483329e4d0c67db057203