### PR TITLE
Add bottom navigation for device and display screens

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -23,11 +23,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity
-            android:name=".ui.DisplayActivity"
-            android:exported="false"
-            android:theme="@style/Theme.G1Hub" />
     </application>
 
 </manifest>

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -1,11 +1,48 @@
 package io.texne.g1.hub.ui
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import io.texne.g1.hub.ui.theme.G1HubTheme
+
+private enum class MainTab(val label: String) {
+    Device("Device"),
+    Display("Display")
+}
 
 @Composable
 fun ApplicationFrame() {
     G1HubTheme {
-        DeviceScreen()
+        var selectedTab by rememberSaveable { mutableStateOf(MainTab.Device) }
+        val tabs = MainTab.values().toList()
+
+        Scaffold(
+            bottomBar = {
+                NavigationBar {
+                    tabs.forEach { tab ->
+                        NavigationBarItem(
+                            selected = tab == selectedTab,
+                            onClick = { selectedTab = tab },
+                            icon = { Text(text = tab.label.take(1)) },
+                            label = { Text(text = tab.label) },
+                            alwaysShowLabel = true
+                        )
+                    }
+                }
+            }
+        ) { innerPadding ->
+            when (selectedTab) {
+                MainTab.Device -> DeviceScreen(modifier = Modifier.padding(innerPadding))
+                MainTab.Display -> DisplayScreen(modifier = Modifier.padding(innerPadding))
+            }
+        }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/DeviceScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/DeviceScreen.kt
@@ -1,6 +1,5 @@
 package io.texne.g1.hub.ui
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +26,7 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun DeviceScreen(
     viewModel: ApplicationViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
@@ -44,7 +43,7 @@ fun DeviceScreen(
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState),
@@ -62,15 +61,5 @@ fun DeviceScreen(
         )
 
         Spacer(modifier = Modifier.height(8.dp))
-
-        Button(
-            onClick = {
-                context.startActivity(Intent(context, DisplayActivity::class.java))
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-        ) {
-            Text(text = "Open Display Screen")
-        }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/ui/DisplayScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/DisplayScreen.kt
@@ -1,9 +1,6 @@
 package io.texne.g1.hub.ui
 
-import android.os.Bundle
 import android.widget.Toast
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,7 +15,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,30 +28,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import dagger.hilt.android.AndroidEntryPoint
 import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.hub.ui.theme.G1HubTheme
 import kotlinx.coroutines.flow.collectLatest
-
-@AndroidEntryPoint
-class DisplayActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContent {
-            G1HubTheme {
-                DisplayScreen(
-                    onBack = { finish() }
-                )
-            }
-        }
-    }
-}
 
 @Composable
 fun DisplayScreen(
-    onBack: () -> Unit,
     viewModel: ApplicationViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
@@ -87,7 +66,7 @@ fun DisplayScreen(
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState)
@@ -140,12 +119,5 @@ fun DisplayScreen(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-
-        TextButton(
-            onClick = onBack,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(text = "Back to Device")
-        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap the app frame in a scaffold with a bottom navigation bar to switch between the Device and Display tabs
- extract the former DisplayActivity UI into a DisplayScreen composable and remove the standalone activity entry
- update DeviceScreen to consume scaffold padding while keeping the scrollable glasses layout

## Testing
- ./gradlew :hub:assembleDebug *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a056d97c8332ad8b67d2ba164184