### PR TITLE
Add MainApplication wiring for React Native host

### DIFF
--- a/android/app/src/main/java/com/teleprompter/MainApplication.kt
+++ b/android/app/src/main/java/com/teleprompter/MainApplication.kt
@@ -1,0 +1,54 @@
+package com.teleprompter
+
+import android.app.Application
+import android.content.res.Configuration
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.soloader.SoLoader
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ReactNativeHostWrapper
+
+class MainApplication : Application(), ReactApplication {
+  private val reactNativeHost: ReactNativeHost by lazy {
+    object : DefaultReactNativeHost(this) {
+      override fun getPackages(): List<ReactPackage> {
+        return PackageList(this).packages
+      }
+
+      override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+      override val isNewArchEnabled: Boolean
+        get() = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+
+      override val isHermesEnabled: Boolean
+        get() = BuildConfig.IS_HERMES_ENABLED
+    }
+  }
+
+  override fun getReactNativeHost(): ReactNativeHost =
+    ReactNativeHostWrapper(this, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      DefaultNewArchitectureEntryPoint.load()
+    }
+
+    if (BuildConfig.DEBUG) {
+      ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+    }
+
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}


### PR DESCRIPTION
## Summary
- add the Android MainApplication entry point implementing ReactApplication
- configure the DefaultReactNativeHost to load packages, support the new architecture flag, and wrap with the Expo host wrapper
- initialize SoLoader and Flipper during application startup while dispatching Expo lifecycle events

## Testing
- ./gradlew assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68e4c5a4391c8332845dbbbe08ff6ec6