### PR TITLE
Fix hub startup blocking to show UI immediately

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -13,13 +13,13 @@
         tools:replace="android:name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.G1Hub"
+        android:theme="@style/Theme.Moncchichi"
         tools:targetApi="31" >
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.G1Hub">
+            android:theme="@style/Theme.Moncchichi">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -6,21 +6,36 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
+import android.os.StrictMode
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.texne.g1.hub.model.Repository
 import io.texne.g1.hub.ui.ApplicationFrame
 import io.texne.g1.hub.ui.ApplicationViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var repository: Repository
 
     private val viewModel: ApplicationViewModel by viewModels()
+
+    private lateinit var statusView: TextView
+    private lateinit var rootView: FrameLayout
+    private var composeAttached = false
 
     private val bluetoothReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -36,12 +51,47 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        repository.bindService()
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyLog()
+                .build()
+        )
+
+        setContentView(R.layout.activity_main)
+        statusView = findViewById(R.id.boot_status)
+        rootView = findViewById(R.id.root)
+        statusView.text = getString(R.string.app_boot_status_rendering)
 
         registerReceiver(bluetoothReceiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
 
-        setContent {
-            ApplicationFrame()
+        lifecycleScope.launch {
+            statusView.text = getString(R.string.app_boot_status_binding)
+            Log.d("Boot", "Attempting to bind service")
+            val bound = repository.bindService()
+            if (!bound) {
+                Log.e("Boot", "Unable to bind service")
+                statusView.text = getString(R.string.app_boot_status_failed)
+                return@launch
+            }
+
+            attachComposeIfNeeded()
+
+            statusView.text = getString(R.string.app_boot_status_waiting)
+            val firstState = withTimeoutOrNull(5000) {
+                repository.getServiceStateFlow()
+                    .filterNotNull()
+                    .first()
+            }
+
+            if (firstState == null) {
+                Log.e("Boot", "Service bind timeout")
+                statusView.text = getString(R.string.app_boot_status_timeout)
+            } else {
+                Log.d("Boot", "Service connected, status=${firstState.status}")
+                statusView.text = getString(R.string.app_boot_status_ready)
+                statusView.visibility = View.GONE
+            }
         }
     }
 
@@ -49,5 +99,20 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
         unregisterReceiver(bluetoothReceiver)
         repository.unbindService()
+    }
+
+    private fun attachComposeIfNeeded() {
+        if (composeAttached) {
+            return
+        }
+        val composeView = ComposeView(this).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            setContent { ApplicationFrame() }
+        }
+        rootView.addView(composeView, 0)
+        composeAttached = true
     }
 }

--- a/hub/src/main/res/layout/activity_main.xml
+++ b/hub/src/main/res/layout/activity_main.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/boot_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/app_boot_status_initial" />
+</FrameLayout>

--- a/hub/src/main/res/values-night/themes.xml
+++ b/hub/src/main/res/values-night/themes.xml
@@ -1,16 +1,8 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
+<resources>
+    <style name="Theme.Moncchichi" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 </resources>

--- a/hub/src/main/res/values/strings.xml
+++ b/hub/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">G1 Hub</string>
+    <string name="app_boot_status_initial">Moncchichi starting…</string>
+    <string name="app_boot_status_rendering">Rendering UI…</string>
+    <string name="app_boot_status_binding">Binding G1 service…</string>
+    <string name="app_boot_status_waiting">Waiting for service response…</string>
+    <string name="app_boot_status_timeout">Service bind timeout. UI is responsive.</string>
+    <string name="app_boot_status_ready">Ready.</string>
+    <string name="app_boot_status_failed">Unable to bind service.</string>
 </resources>

--- a/hub/src/main/res/values/themes.xml
+++ b/hub/src/main/res/values/themes.xml
@@ -1,16 +1,8 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.G1Hub" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
+<resources>
+    <style name="Theme.Moncchichi" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 </resources>

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -12,6 +12,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
@@ -169,6 +170,7 @@ class G1Service : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        Log.d("G1Service", "onCreate")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             withPermissions { ensureForegroundNotification() }
         }
@@ -201,6 +203,7 @@ class G1Service : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
 
     override fun onBind(intent: Intent?): IBinder? {
+        Log.d("G1Service", "onBind action=${intent?.action}")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             applicationContext.startForegroundService(Intent(applicationContext, G1Service::class.java))
         } else {


### PR DESCRIPTION
## Summary
- switch the Android hub launcher to an AppCompat activity that inflates a fallback layout, applies StrictMode, and binds to the service asynchronously
- expose a repository service state flow that is safe to read before binding and add boot status strings/theme adjustments so the UI renders immediately
- log service lifecycle events and ensure the binder runs without blocking the main thread

## Testing
- `./gradlew clean`
- `./gradlew assembleDebug --stacktrace` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d6e0fdf48332a29fa1e40030e793