### PR TITLE
Add post-connection ping handling

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/G1DisplayService.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1DisplayService.kt
@@ -36,8 +36,8 @@ class G1DisplayService : Service() {
     }
 
     class G1Binder : Binder() {
-        fun pingBinder() {
-            Log.d("G1Service", "pingBinder() called")
+        fun heartbeat() {
+            Log.d("G1Service", "heartbeat() called")
         }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/G1DisplayService.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1DisplayService.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.cancel
 
 class G1DisplayService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val binder = G1Binder()
 
     override fun onCreate() {
         super.onCreate()
@@ -20,7 +21,7 @@ class G1DisplayService : Service() {
 
     override fun onBind(intent: Intent?): IBinder {
         Log.d("G1Service", "onBind()")
-        return Binder()
+        return binder
     }
 
     override fun onUnbind(intent: Intent?): Boolean {
@@ -32,5 +33,11 @@ class G1DisplayService : Service() {
         Log.d("G1Service", "onDestroy()")
         scope.cancel()
         super.onDestroy()
+    }
+
+    class G1Binder : Binder() {
+        fun pingBinder() {
+            Log.d("G1Service", "pingBinder() called")
+        }
     }
 }

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity() {
 
     private suspend fun g1PingService(): String = withContext(Dispatchers.IO) {
         return@withContext try {
-            binder?.pingBinder() ?: throw IllegalStateException("Binder unavailable")
+            binder?.heartbeat() ?: throw IllegalStateException("Binder unavailable")
             Log.d("Boot", "Ping OK")
             "G1 Display ready ✅"
         } catch (t: Throwable) {

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -15,22 +15,26 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 
 class MainActivity : AppCompatActivity() {
     private lateinit var status: TextView
     private var bound = false
+    private var binder: G1DisplayService.G1Binder? = null
 
     private val conn = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             bound = true
+            binder = service as? G1DisplayService.G1Binder
             ServiceRepository.setConnected()
             Log.d("Boot", "Service connected on binder thread")
             runOnUiThread { status.setText(R.string.boot_service_connected) }
         }
         override fun onServiceDisconnected(name: ComponentName?) {
             bound = false
+            binder = null
             ServiceRepository.setDisconnected()
             Log.w("Boot", "Service disconnected")
         }
@@ -67,6 +71,28 @@ class MainActivity : AppCompatActivity() {
                 status.setText(R.string.boot_service_timeout)
             }
         }
+
+        lifecycleScope.launch {
+            ServiceRepository.state.collect { state ->
+                when (state) {
+                    ServiceState.CONNECTED -> {
+                        Log.d("Boot", "Repository state = CONNECTED")
+                        status.text = "Connected. Initializing data..."
+                        delay(1000)
+                        try {
+                            val msg = g1PingService()
+                            status.text = msg
+                        } catch (t: Throwable) {
+                            status.text = "Ping failed: ${t.message}"
+                        }
+                    }
+                    ServiceState.DISCONNECTED -> status.text = "Disconnected"
+                    ServiceState.ERROR -> status.text = "Error - check logs"
+                    ServiceState.BINDING -> status.setText(R.string.boot_service_binding)
+                    else -> Unit
+                }
+            }
+        }
     }
 
     private suspend fun bindServiceAwait(): Boolean = suspendCancellableCoroutine { cont ->
@@ -90,6 +116,7 @@ class MainActivity : AppCompatActivity() {
             if (bound) {
                 unbindService(conn)
                 bound = false
+                binder = null
                 ServiceRepository.setDisconnected()
             }
         }
@@ -100,7 +127,19 @@ class MainActivity : AppCompatActivity() {
         if (bound) {
             unbindService(conn)
             bound = false
+            binder = null
             ServiceRepository.setDisconnected()
+        }
+    }
+
+    private suspend fun g1PingService(): String = withContext(Dispatchers.IO) {
+        return@withContext try {
+            binder?.pingBinder() ?: throw IllegalStateException("Binder unavailable")
+            Log.d("Boot", "Ping OK")
+            "G1 Display ready ✅"
+        } catch (t: Throwable) {
+            Log.e("Boot", "Ping failed", t)
+            "Ping failed ❌"
         }
     }
 }


### PR DESCRIPTION
## Summary
- observe the service state flow in `MainActivity` to transition the boot UI once binding completes
- add a background ping helper that confirms the binder connection and updates the status message
- expose a lightweight `pingBinder` heartbeat from `G1DisplayService`

## Testing
- ./gradlew :hub:lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e88b3d58833294015105a8e77113