### PR TITLE
Ensure ready state UI update occurs on main thread

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -74,6 +74,7 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             ServiceRepository.state.collect { state ->
+                Log.d("Boot", "Collecting state = $state on thread ${Thread.currentThread().name}")
                 when (state) {
                     ServiceState.CONNECTED -> {
                         Log.d("Boot", "Repository state = CONNECTED")
@@ -81,7 +82,19 @@ class MainActivity : AppCompatActivity() {
                         delay(1000)
                         try {
                             val msg = g1PingService()
-                            status.text = msg
+                            withContext(Dispatchers.Main) {
+                                status.text = msg
+                            }
+
+                            if (msg.contains("ready")) {
+                                Log.d("Boot", "Scheduling final transition to ready state")
+                                delay(1500)
+                                withContext(Dispatchers.Main) {
+                                    status.text = "Moncchichi ready to use 🎉"
+                                }
+                            } else {
+                                Log.d("Boot", "No 'ready' message match; staying on tick screen")
+                            }
                         } catch (t: Throwable) {
                             status.text = "Ping failed: ${t.message}"
                         }


### PR DESCRIPTION
## Summary
- add debug logging around service state collection to trace thread usage
- update ready-state UI transitions to run on the main dispatcher and log scheduling decisions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ecbb45fc8332975c15fa9f77a57b