### PR TITLE
Add automatic reconnection workflow for G1 display service

### DIFF
--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -178,15 +178,21 @@ class MainActivity : AppCompatActivity() {
         connectionStateJob = lifecycleScope.launch {
             g1Binder.stateFlow.collectLatest { state ->
                 when (state) {
-                    G1ConnectionState.WAITING_FOR_RECONNECT -> {
-                        status.text = "Connection lost, attempting to reconnect..."
-                    }
                     G1ConnectionState.CONNECTED -> {
                         if (lastConnectionState == G1ConnectionState.WAITING_FOR_RECONNECT) {
-                            status.text = "Moncchichi ready to use 🎉"
+                            delay(500)
                         }
+                        status.text = "Moncchichi ready 🎉"
                     }
-                    else -> Unit
+                    G1ConnectionState.WAITING_FOR_RECONNECT -> {
+                        status.text = "Reconnecting..."
+                    }
+                    G1ConnectionState.DISCONNECTED -> {
+                        status.text = "Connection lost"
+                    }
+                    else -> {
+                        status.text = "Connecting..."
+                    }
                 }
                 lastConnectionState = state
             }


### PR DESCRIPTION
## Summary
- add a reusable GATT callback and coroutine-based reconnect loop in `DeviceManager`
- monitor for reconnect-needed states inside `G1DisplayService` and trigger automatic retries with state updates
- refresh the hub UI copy to reflect reconnect progress and show the ready state after a short delay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e500142ef08332beac2aa5038546cb