### PR TITLE
Stability Enhancement: Add ConnectionState Enum, Retry Backoff, and Initialization Guards

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -25,9 +25,9 @@
         </activity>
 
         <service
-            android:name=".G1DisplayService"
+            android:name=".service.G1DisplayService"
             android:exported="true"
-            android:foregroundServiceType="connectedDevice" />
+            android:foregroundServiceType="connectedDevice|dataSync" />
     </application>
 
 </manifest>

--- a/hub/src/main/java/com/loopermallee/moncchichi/bluetooth/G1ConnectionState.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/bluetooth/G1ConnectionState.kt
@@ -2,8 +2,7 @@ package com.loopermallee.moncchichi.bluetooth
 
 enum class G1ConnectionState {
     DISCONNECTED,
-    CONNECTING,
-    CONNECTED,
     WAITING_FOR_RECONNECT,
     RECONNECTING,
+    CONNECTED,
 }

--- a/hub/src/main/java/com/loopermallee/moncchichi/service/G1DisplayService.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/service/G1DisplayService.kt
@@ -70,6 +70,7 @@ class G1DisplayService : Service() {
                 updateNotification(state)
                 when (state) {
                     G1ConnectionState.WAITING_FOR_RECONNECT -> scheduleReconnects()
+                    G1ConnectionState.RECONNECTING -> scheduleReconnects()
                     G1ConnectionState.DISCONNECTED -> reconnectJob?.cancel()
                     G1ConnectionState.CONNECTED -> reconnectJob?.cancel()
                 }

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.loopermallee.moncchichi.bluetooth.G1ConnectionState
+import com.loopermallee.moncchichi.service.G1DisplayService
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -109,7 +110,6 @@ class MainActivity : AppCompatActivity() {
                     G1ConnectionState.CONNECTED -> getString(R.string.status_connected_green)
                     G1ConnectionState.RECONNECTING -> getString(R.string.status_reconnecting_yellow)
                     G1ConnectionState.WAITING_FOR_RECONNECT -> getString(R.string.status_waiting_red)
-                    G1ConnectionState.CONNECTING -> getString(R.string.status_connecting)
                     G1ConnectionState.DISCONNECTED -> getString(R.string.status_disconnected)
                 }
             }


### PR DESCRIPTION
## Summary
- refactor the BLE DeviceManager to use a four-state connection enum, guard concurrent initialization, and retry with capped exponential backoff
- move the G1DisplayService into the moncchichi.service package, register a screen-on reconnect broadcast, and expose a reconnect entry point to clients while updating notifications
- add debug logging helpers with log file rotation, update the manifest service declaration, and align the UI with the new connection state model

## Testing
- ./gradlew -p hub test --console=plain *(fails: Android SDK missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e53b0462508332ab831bd708acde4e