### PR TITLE
feat: add crash diagnostics failsafe activity

### DIFF
--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -11,19 +11,27 @@
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/Theme.Moncchichi">
+        android:theme="@android:style/Theme.DeviceDefault">
 
+        <!-- Failsafe Diagnostic Activity -->
         <activity
-            android:name=".MainActivity"
+            android:name=".FailsafeMainActivity"
             android:exported="true"
-            android:launchMode="singleTop">
+            android:process=":failsafe"
+            android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
 
-        <!-- Removed duplicate G1DisplayService to prevent merge conflicts -->
+        <!-- Keep normal main activity disabled for now -->
+        <!-- <activity android:name=".MainActivity" android:exported="true" /> -->
+
+        <service
+            android:name=".service.G1DisplayService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice|dataSync" />
     </application>
 
 </manifest>

--- a/hub/src/main/java/com/loopermallee/moncchichi/FailsafeMainActivity.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/FailsafeMainActivity.kt
@@ -1,0 +1,41 @@
+package com.loopermallee.moncchichi
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Bundle
+import android.widget.ScrollView
+import android.widget.TextView
+import java.io.File
+
+class FailsafeMainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val textView = TextView(this).apply {
+            text = "\uD83D\uDD0D Booting Moncchichi diagnostics...\n"
+            setTextColor(Color.WHITE)
+            setBackgroundColor(Color.BLACK)
+            textSize = 14f
+            setPadding(24, 48, 24, 24)
+        }
+
+        val scrollView = ScrollView(this).apply {
+            addView(textView)
+        }
+
+        setContentView(scrollView)
+
+        try {
+            val crashFile = File(filesDir, "last_crash.txt")
+            if (crashFile.exists()) {
+                textView.append("\n\uD83D\uDCC4 Previous crash log:\n\n" + crashFile.readText())
+            } else {
+                textView.append("\n✅ No previous crash log found.")
+            }
+
+            textView.append("\n\n\uD83D\uDCBC App files path:\n${filesDir.absolutePath}")
+        } catch (e: Exception) {
+            textView.append("\n❌ Failsafe error: ${e.message}")
+        }
+    }
+}

--- a/hub/src/main/java/com/loopermallee/moncchichi/MoncchichiApp.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/MoncchichiApp.kt
@@ -1,0 +1,73 @@
+package com.loopermallee.moncchichi
+
+import android.app.Application
+import android.app.AlertDialog
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.EditText
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+
+class MoncchichiApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // Install global crash handler
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
+            val sw = StringWriter()
+            throwable.printStackTrace(PrintWriter(sw))
+            val errorText = sw.toString()
+
+            Log.e("CrashGuard", "Uncaught exception: $errorText")
+
+            // Save crash log for later review
+            try {
+                val file = File(filesDir, "last_crash.txt")
+                file.writeText(errorText)
+            } catch (_: Exception) {}
+
+            // Show a dialog with copyable text
+            Handler(Looper.getMainLooper()).post {
+                try {
+                    showCrashDialog(this, throwable, errorText)
+                } catch (e: Exception) {
+                    Log.e("CrashGuard", "Unable to show crash dialog: ${e.message}")
+                }
+            }
+
+            // Give UI time to render
+            Thread.sleep(4000)
+            android.os.Process.killProcess(android.os.Process.myPid())
+            System.exit(1)
+        }
+
+        Log.i("AppBoot", "MoncchichiApp started at ${System.currentTimeMillis()}")
+    }
+
+    private fun showCrashDialog(context: Context, throwable: Throwable, details: String) {
+        val input = EditText(context)
+        input.setText("⚠️ Crash detected:\n${throwable::class.simpleName}: ${throwable.message}\n\n$details")
+        input.isSingleLine = false
+        input.isFocusable = true
+        input.isFocusableInTouchMode = true
+        input.setSelection(0, 0)
+        input.setTextIsSelectable(true)
+        input.minLines = 10
+        input.maxLines = 20
+
+        AlertDialog.Builder(context)
+            .setTitle("Moncchichi Crash Report")
+            .setView(input)
+            .setPositiveButton("Copy & Exit") { dialog, _ ->
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("CrashReport", input.text.toString()))
+                dialog.dismiss()
+            }
+            .setCancelable(false)
+            .show()
+    }
+}


### PR DESCRIPTION
## Summary
- add an Application subclass that installs a global uncaught-exception handler
- log crash details, persist them to local storage, and show a copyable dialog for the user
- introduce a dedicated failsafe activity and manifest wiring to surface stored crash info during startup issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f519df548332ab8ae2417e4b4894