### PR TITLE
Add minimal TestActivity and manifest validation task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,20 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
 }
+
+tasks.register("validateManifests") {
+    doLast {
+        fileTree(rootDir) {
+            include("**/AndroidManifest.xml")
+        }.forEach {
+            println("Checking manifest: ${it.path}")
+            val text = it.readText()
+            if ("<application" !in text) {
+                println("⚠️ Missing <application> tag in ${it.path}")
+            }
+            if (text.contains("android:name=\"android.app.Application\"")) {
+                println("⚠️ Uses system Application instead of custom MoncchichiApp: ${it.path}")
+            }
+        }
+    }
+}

--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -1,37 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_CONNECT"
-        android:usesPermissionFlags="neverForLocation" />
-
     <application
-        android:name=".MoncchichiApp"
-        android:label="@string/app_name"
-        android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="MoncchichiTest"
         android:theme="@android:style/Theme.DeviceDefault">
 
-        <!-- Failsafe Diagnostic Activity -->
         <activity
-            android:name=".FailsafeMainActivity"
-            android:exported="true"
-            android:process=":failsafe"
-            android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+            android:name=".TestActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <!-- Keep normal main activity disabled for now -->
-        <!-- <activity android:name=".MainActivity" android:exported="true" /> -->
-
-        <service
-            android:name=".service.G1DisplayService"
-            android:exported="false"
-            android:foregroundServiceType="connectedDevice|dataSync" />
     </application>
 
 </manifest>

--- a/hub/src/main/java/com/loopermallee/moncchichi/TestActivity.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/TestActivity.kt
@@ -1,0 +1,14 @@
+package com.loopermallee.moncchichi
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+
+class TestActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val tv = TextView(this)
+        tv.text = "✅ Minimal build started successfully"
+        setContentView(tv)
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal TestActivity and simplify the hub manifest to isolate startup crashes
- register a Gradle task to print basic diagnostics for every AndroidManifest.xml in the repo

## Testing
- ./gradlew clean
- ./gradlew assembleDebug --no-build-cache --stacktrace *(fails: Android SDK not configured in CI environment)*
- ./gradlew validateManifests

------
https://chatgpt.com/codex/tasks/task_e_68e5fbef6fe08332ae03e70050f20124