### PR TITLE
Refactor packages and add crash probe diagnostics

### DIFF
--- a/aidl/build.gradle.kts
+++ b/aidl/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.basis.aidl"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {

--- a/aidl/publishing/client-service-bridge-1.1.0.pom
+++ b/aidl/publishing/client-service-bridge-1.1.0.pom
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.texne.g1.basis</groupId>
+  <groupId>com.loopermallee.moncchichi</groupId>
   <artifactId>client-service-bridge</artifactId>
   <packaging>aar</packaging>
 

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
@@ -1,3 +1,3 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
 parcelable G1Glasses;

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1ServiceState.aidl
@@ -1,6 +1,6 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.G1Glasses;
+import com.loopermallee.moncchichi.service.protocol.G1Glasses;
 
 parcelable G1ServiceState {
     const int READY = 0;

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1State.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/G1State.aidl
@@ -1,3 +1,3 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
 parcelable G1State;

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1Service.aidl
@@ -1,7 +1,7 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.IG1StateCallback;
-import io.texne.g1.basis.service.protocol.OperationCallback;
+import com.loopermallee.moncchichi.service.protocol.IG1StateCallback;
+import com.loopermallee.moncchichi.service.protocol.OperationCallback;
 
 interface IG1Service {
     void observeState(IG1StateCallback callback);

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1ServiceClient.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1ServiceClient.aidl
@@ -1,9 +1,9 @@
 // IG1ServiceClient.aidl
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.G1Glasses;
-import io.texne.g1.basis.service.protocol.ObserveStateCallback;
-import io.texne.g1.basis.service.protocol.OperationCallback;
+import com.loopermallee.moncchichi.service.protocol.G1Glasses;
+import com.loopermallee.moncchichi.service.protocol.ObserveStateCallback;
+import com.loopermallee.moncchichi.service.protocol.OperationCallback;
 
 interface IG1ServiceClient {
     void observeState(ObserveStateCallback callback);

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1StateCallback.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/IG1StateCallback.aidl
@@ -1,6 +1,6 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.G1Glasses;
+import com.loopermallee.moncchichi.service.protocol.G1Glasses;
 
 interface IG1StateCallback {
     void onStateChanged(int status, in G1Glasses[] glasses);

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/ObserveStateCallback.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/ObserveStateCallback.aidl
@@ -1,6 +1,6 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.G1ServiceState;
+import com.loopermallee.moncchichi.service.protocol.G1ServiceState;
 
 interface ObserveStateCallback {
     void onStateChange(in G1ServiceState state);

--- a/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/OperationCallback.aidl
+++ b/aidl/src/main/aidl/io/texne/g1/basis/service/protocol/OperationCallback.aidl
@@ -1,5 +1,5 @@
 // OperationCallback.aidl
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
 interface OperationCallback {
     void onResult(boolean success);

--- a/aidl/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.java
+++ b/aidl/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.java
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
 import android.os.Parcel;
 import android.os.Parcelable;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,21 +14,10 @@
         android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
-            android:exported="true"
-            android:theme="@style/AppTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="g1ot" />
-            </intent-filter>
-        </activity>
+            android:exported="false"
+            android:theme="@style/AppTheme" />
         <service
-            android:name="io.texne.g1.basis.service.G1DisplayService"
+            android:name="com.loopermallee.moncchichi.service.G1DisplayService"
             android:exported="true"
             android:enabled="true" />
     </application>

--- a/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
+++ b/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
@@ -1,3 +1,3 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
 parcelable G1Glasses;

--- a/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/IG1DisplayService.aidl
+++ b/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/IG1DisplayService.aidl
@@ -1,6 +1,6 @@
-package io.texne.g1.basis.service.protocol;
+package com.loopermallee.moncchichi.service.protocol;
 
-import io.texne.g1.basis.service.protocol.G1Glasses;
+import com.loopermallee.moncchichi.service.protocol.G1Glasses;
 
 interface IG1DisplayService {
     /** Send a new text to display / scroll */

--- a/android/app/src/main/java/com/teleprompter/MainActivity.kt
+++ b/android/app/src/main/java/com/teleprompter/MainActivity.kt
@@ -10,8 +10,8 @@ import android.os.IBinder
 import android.util.Log
 import android.view.Gravity
 import android.widget.TextView
-import io.texne.g1.basis.service.G1DisplayService
-import io.texne.g1.basis.service.protocol.IG1DisplayService
+import com.loopermallee.moncchichi.service.G1DisplayService
+import com.loopermallee.moncchichi.service.protocol.IG1DisplayService
 
 class MainActivity : Activity() {
     private var displayService: IG1DisplayService? = null

--- a/android/app/src/main/java/io/texne/g1/basis/service/G1DisplayService.kt
+++ b/android/app/src/main/java/io/texne/g1/basis/service/G1DisplayService.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.service
+package com.loopermallee.moncchichi.service
 
 import android.app.Service
 import android.content.Intent
@@ -6,8 +6,8 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.util.Log
-import io.texne.g1.basis.service.protocol.G1Glasses
-import io.texne.g1.basis.service.protocol.IG1DisplayService
+import com.loopermallee.moncchichi.service.protocol.G1Glasses
+import com.loopermallee.moncchichi.service.protocol.IG1DisplayService
 
 /**
  * Binder backed service that accepts teleprompter text commands from external clients

--- a/android/app/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.kt
+++ b/android/app/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.service.protocol
+package com.loopermallee.moncchichi.service.protocol
 
 import android.os.Parcel
 import android.os.Parcelable

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.basis.client"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {

--- a/client/publishing/client-1.1.1.pom
+++ b/client/publishing/client-1.1.1.pom
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.texne.g1.basis</groupId>
+  <groupId>com.loopermallee.moncchichi</groupId>
   <artifactId>client</artifactId>
   <packaging>aar</packaging>
 
@@ -61,7 +61,7 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.texne.g1.basis</groupId>
+      <groupId>com.loopermallee.moncchichi</groupId>
       <artifactId>client-service-bridge</artifactId>
       <version>1.1.0</version>
       <scope>runtime</scope>

--- a/client/src/main/AndroidManifest.xml
+++ b/client/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
-        <package android:name="io.texne.g1.hub" />
+        <package android:name="com.loopermallee.moncchichi" />
     </queries>
-    <uses-permission android:name="io.texne.g1.basis.permission.CONNECT_TO_SERVICE"/>
+    <uses-permission android:name="com.loopermallee.moncchichi.permission.CONNECT_TO_SERVICE"/>
 </manifest>

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceClient.kt
@@ -1,14 +1,14 @@
-package io.texne.g1.basis.client
+package com.loopermallee.moncchichi.client
 
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
-import io.texne.g1.basis.service.protocol.G1Glasses
-import io.texne.g1.basis.service.protocol.G1ServiceState
-import io.texne.g1.basis.service.protocol.IG1ServiceClient
-import io.texne.g1.basis.service.protocol.ObserveStateCallback
+import com.loopermallee.moncchichi.service.protocol.G1Glasses
+import com.loopermallee.moncchichi.service.protocol.G1ServiceState
+import com.loopermallee.moncchichi.service.protocol.IG1ServiceClient
+import com.loopermallee.moncchichi.service.protocol.ObserveStateCallback
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -17,8 +17,8 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
     companion object {
         fun open(context: Context): G1ServiceClient? {
             val client = G1ServiceClient(context)
-            val intent = Intent("io.texne.g1.basis.service.protocol.IG1ServiceClient")
-            intent.setClassName("io.texne.g1.hub", "io.texne.g1.basis.service.G1Service")
+            val intent = Intent("com.loopermallee.moncchichi.service.protocol.IG1ServiceClient")
+            intent.setClassName("com.loopermallee.moncchichi", "com.loopermallee.moncchichi.service.G1Service")
             if (context.bindService(
                     intent,
                     client.serviceConnection,
@@ -32,7 +32,7 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
 
         fun openHub(context: Context) {
             context.startActivity(Intent(Intent.ACTION_MAIN).also {
-                it.setClassName("io.texne.g1.hub", "io.texne.g1.hub.MainActivity")
+                it.setClassName("com.loopermallee.moncchichi", "com.loopermallee.moncchichi.TestActivity")
             })
         }
     }
@@ -96,7 +96,7 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
             service?.displayTextPage(
                 id,
                 page.toTypedArray(),
-                object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
+                object : com.loopermallee.moncchichi.service.protocol.OperationCallback.Stub() {
                     override fun onResult(success: Boolean) {
                         continuation.resume(success)
                     }
@@ -106,7 +106,7 @@ class G1ServiceClient private constructor(context: Context): G1ServiceCommon<IG1
     override suspend fun stopDisplaying(id: String) = suspendCoroutine<Boolean> { continuation ->
         service?.stopDisplaying(
             id,
-            object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
+            object : com.loopermallee.moncchichi.service.protocol.OperationCallback.Stub() {
                 override fun onResult(success: Boolean) {
                     continuation.resume(success)
                 }

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceCommon.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.client
+package com.loopermallee.moncchichi.client
 
 import android.content.Context
 import android.content.ServiceConnection

--- a/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
+++ b/client/src/main/java/io/texne/g1/basis/client/G1ServiceManager.kt
@@ -1,14 +1,14 @@
-package io.texne.g1.basis.client
+package com.loopermallee.moncchichi.client
 
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
-import io.texne.g1.basis.service.protocol.G1Glasses
-import io.texne.g1.basis.service.protocol.G1ServiceState
-import io.texne.g1.basis.service.protocol.IG1Service
-import io.texne.g1.basis.service.protocol.IG1StateCallback
+import com.loopermallee.moncchichi.service.protocol.G1Glasses
+import com.loopermallee.moncchichi.service.protocol.G1ServiceState
+import com.loopermallee.moncchichi.service.protocol.IG1Service
+import com.loopermallee.moncchichi.service.protocol.IG1StateCallback
 import kotlin.collections.buildList
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -18,8 +18,8 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
     companion object {
         fun open(context: Context): G1ServiceManager? {
             val client = G1ServiceManager(context)
-            val intent = Intent("io.texne.g1.basis.service.protocol.IG1Service")
-            intent.setClassName(context.packageName, "io.texne.g1.basis.service.G1Service")
+            val intent = Intent("com.loopermallee.moncchichi.service.protocol.IG1Service")
+            intent.setClassName(context.packageName, "com.loopermallee.moncchichi.service.G1Service")
             if (context.bindService(
                     intent,
                     client.serviceConnection,
@@ -89,7 +89,7 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
     suspend fun connect(id: String) = suspendCoroutine<Boolean> { continuation ->
         service?.connectGlasses(
             id,
-            object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
+            object : com.loopermallee.moncchichi.service.protocol.OperationCallback.Stub() {
                 override fun onResult(success: Boolean) {
                     continuation.resume(success)
                 }
@@ -119,7 +119,7 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
             service?.displayTextPage(
                 id,
                 page.toTypedArray(),
-                object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
+                object : com.loopermallee.moncchichi.service.protocol.OperationCallback.Stub() {
                     override fun onResult(success: Boolean) {
                         continuation.resume(success)
                     }
@@ -129,7 +129,7 @@ class G1ServiceManager private constructor(context: Context): G1ServiceCommon<IG
     override suspend fun stopDisplaying(id: String) = suspendCoroutine<Boolean> { continuation ->
         service?.stopDisplaying(
             id,
-            object : io.texne.g1.basis.service.protocol.OperationCallback.Stub() {
+            object : com.loopermallee.moncchichi.service.protocol.OperationCallback.Stub() {
                 override fun onResult(success: Boolean) {
                     continuation.resume(success)
                 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.basis.core"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {

--- a/core/publishing/core-1.0.1.pom
+++ b/core/publishing/core-1.0.1.pom
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.texne.g1.basis</groupId>
+  <groupId>com.loopermallee.moncchichi</groupId>
   <artifactId>core</artifactId>
   <packaging>aar</packaging>
 

--- a/core/src/main/java/io/texne/g1/basis/core/G1.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.core
+package com.loopermallee.moncchichi.core
 
 import android.annotation.SuppressLint
 import android.content.Context

--- a/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1BLEManager.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.core
+package com.loopermallee.moncchichi.core
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice

--- a/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/G1Device.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.core
+package com.loopermallee.moncchichi.core
 
 import android.annotation.SuppressLint
 import android.content.Context

--- a/core/src/main/java/io/texne/g1/basis/core/G1State.java
+++ b/core/src/main/java/io/texne/g1/basis/core/G1State.java
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.core;
+package com.loopermallee.moncchichi.core;
 
 public final class G1State {
     private G1State() {}

--- a/core/src/main/java/io/texne/g1/basis/core/protocol.kt
+++ b/core/src/main/java/io/texne/g1/basis/core/protocol.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.core
+package com.loopermallee.moncchichi.core
 
 // bluetooth device name ---------------------------------------------------------------------------
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
-basis-client = { group = "io.texne.g1.basis", name = "client", version.ref = "basisClient"}
-basis-service = { group = "io.texne.g1.basis", name = "service", version.ref = "basisService"}
+basis-client = { group = "com.loopermallee.moncchichi", name = "client", version.ref = "basisClient"}
+basis-service = { group = "com.loopermallee.moncchichi", name = "service", version.ref = "basisService"}
 androidx-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIcons"}
 
 [plugins]

--- a/hub/build.gradle.kts
+++ b/hub/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.hub"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "io.texne.g1.hub"
+        applicationId = "com.loopermallee.moncchichi"
         minSdk = 24
         targetSdk = 35
         versionCode = 1

--- a/hub/src/main/AndroidManifest.xml
+++ b/hub/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:label="MoncchichiTest"
+        android:name=".CrashProbeApp"
+        android:label="MoncchichiProbe"
         android:theme="@android:style/Theme.DeviceDefault">
 
         <activity

--- a/hub/src/main/java/com/loopermallee/moncchichi/CrashProbeApp.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/CrashProbeApp.kt
@@ -1,0 +1,11 @@
+package com.loopermallee.moncchichi
+
+import android.app.Application
+import android.util.Log
+
+class CrashProbeApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        Log.i("CrashProbe", "✅ CrashProbeApp started successfully")
+    }
+}

--- a/hub/src/main/java/com/loopermallee/moncchichi/service/G1DisplayService.kt
+++ b/hub/src/main/java/com/loopermallee/moncchichi/service/G1DisplayService.kt
@@ -17,8 +17,8 @@ import androidx.core.app.NotificationCompat
 import com.loopermallee.moncchichi.MoncchichiLogger
 import com.loopermallee.moncchichi.bluetooth.DeviceManager
 import com.loopermallee.moncchichi.bluetooth.G1ConnectionState
-import io.texne.g1.hub.MainActivity
-import io.texne.g1.hub.R
+import com.loopermallee.moncchichi.hub.MainActivity
+import com.loopermallee.moncchichi.hub.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
+++ b/hub/src/main/java/io/texne/g1/hub/G1HubApplication.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub
+package com.loopermallee.moncchichi.hub
 
 import android.app.Application
 import com.loopermallee.moncchichi.CrashHandler
@@ -6,7 +6,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
-import io.texne.g1.hub.BuildConfig
+import com.loopermallee.moncchichi.hub.BuildConfig
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
+++ b/hub/src/main/java/io/texne/g1/hub/MainActivity.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub
+package com.loopermallee.moncchichi.hub
 
 import android.content.ComponentName
 import android.content.Context

--- a/hub/src/main/java/io/texne/g1/hub/ServiceRepository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ServiceRepository.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub
+package com.loopermallee.moncchichi.hub
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
+++ b/hub/src/main/java/io/texne/g1/hub/model/Repository.kt
@@ -1,9 +1,9 @@
-package io.texne.g1.hub.model
+package com.loopermallee.moncchichi.hub.model
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.basis.client.G1ServiceManager
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.client.G1ServiceManager
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationFrame.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui
+package com.loopermallee.moncchichi.hub.ui
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.NavigationBar
@@ -11,7 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import io.texne.g1.hub.ui.theme.G1HubTheme
+import com.loopermallee.moncchichi.hub.ui.theme.G1HubTheme
 
 private enum class MainTab(val label: String) {
     Device("Device"),

--- a/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/ApplicationViewModel.kt
@@ -1,11 +1,11 @@
-package io.texne.g1.hub.ui
+package com.loopermallee.moncchichi.hub.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.basis.client.G1ServiceCommon.ServiceStatus
-import io.texne.g1.hub.model.Repository
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.client.G1ServiceCommon.ServiceStatus
+import com.loopermallee.moncchichi.hub.model.Repository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow

--- a/hub/src/main/java/io/texne/g1/hub/ui/DeviceScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/DeviceScreen.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui
+package com.loopermallee.moncchichi.hub.ui
 
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -21,9 +21,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.hub.ui.glasses.GlassesScreen
-import io.texne.g1.hub.ui.glasses.displayName
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.hub.ui.glasses.GlassesScreen
+import com.loopermallee.moncchichi.hub.ui.glasses.displayName
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable

--- a/hub/src/main/java/io/texne/g1/hub/ui/DisplayScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/DisplayScreen.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui
+package com.loopermallee.moncchichi.hub.ui
 
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -38,12 +38,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.hub.ui.glasses.batteryLabel
-import io.texne.g1.hub.ui.glasses.displayName
-import io.texne.g1.hub.ui.glasses.firmwareLabel
-import io.texne.g1.hub.ui.glasses.statusColor
-import io.texne.g1.hub.ui.glasses.statusText
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.hub.ui.glasses.batteryLabel
+import com.loopermallee.moncchichi.hub.ui.glasses.displayName
+import com.loopermallee.moncchichi.hub.ui.glasses.firmwareLabel
+import com.loopermallee.moncchichi.hub.ui.glasses.statusColor
+import com.loopermallee.moncchichi.hub.ui.glasses.statusText
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable

--- a/hub/src/main/java/io/texne/g1/hub/ui/glasses/GlassesScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/glasses/GlassesScreen.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui.glasses
+package com.loopermallee.moncchichi.hub.ui.glasses
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -35,17 +35,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.basis.client.G1ServiceCommon.GlassesStatus
-import io.texne.g1.basis.client.G1ServiceCommon.ServiceStatus
-import io.texne.g1.hub.ui.theme.Bof4Coral
-import io.texne.g1.hub.ui.theme.Bof4Midnight
-import io.texne.g1.hub.ui.theme.Bof4Mist
-import io.texne.g1.hub.ui.theme.Bof4Sand
-import io.texne.g1.hub.ui.theme.Bof4Sky
-import io.texne.g1.hub.ui.theme.Bof4Steel
-import io.texne.g1.hub.ui.theme.Bof4Verdant
-import io.texne.g1.hub.ui.theme.Bof4Warning
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.client.G1ServiceCommon.GlassesStatus
+import com.loopermallee.moncchichi.client.G1ServiceCommon.ServiceStatus
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Coral
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Midnight
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Mist
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Sand
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Sky
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Steel
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Verdant
+import com.loopermallee.moncchichi.hub.ui.theme.Bof4Warning
 import java.util.Locale
 
 private val ConnectedColor = Bof4Verdant

--- a/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/scanner/ScannerScreen.kt
@@ -1,3 +1,5 @@
+package com.loopermallee.moncchichi.hub.ui.scanner
+
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -27,8 +29,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.hub.R
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.hub.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Color.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui.theme
+package com.loopermallee.moncchichi.hub.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Theme.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui.theme
+package com.loopermallee.moncchichi.hub.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme

--- a/hub/src/main/java/io/texne/g1/hub/ui/theme/Type.kt
+++ b/hub/src/main/java/io/texne/g1/hub/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.hub.ui.theme
+package com.loopermallee.moncchichi.hub.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/scripts/check_manifests.kts
+++ b/scripts/check_manifests.kts
@@ -1,0 +1,19 @@
+import java.io.File
+
+fun main() {
+    val manifests = File(".").walkTopDown()
+        .filter { it.name == "AndroidManifest.xml" }
+        .filterNot { it.path.contains("${File.separator}build${File.separator}") }
+    manifests.forEach {
+        println("\uD83D\uDD0D Checking: ${it.path}")
+        val text = it.readText()
+        if (!text.contains("<application"))
+            println("\u26A0\uFE0F Missing <application> tag in ${it.path}")
+        if (text.contains("android.intent.category.LAUNCHER"))
+            println("\uD83D\uDE80 MAIN/LAUNCHER found in ${it.path}")
+        if (text.contains("io.texne.g1.basis"))
+            println("\u26A0\uFE0F Legacy package reference in ${it.path}")
+    }
+}
+
+main()

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.basis.service"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {

--- a/service/publishing/service-1.1.0.pom
+++ b/service/publishing/service-1.1.0.pom
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.texne.g1.basis</groupId>
+  <groupId>com.loopermallee.moncchichi</groupId>
   <artifactId>service</artifactId>
   <packaging>aar</packaging>
 
@@ -79,19 +79,19 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.texne.g1.basis</groupId>
+      <groupId>com.loopermallee.moncchichi</groupId>
       <artifactId>client</artifactId>
       <version>1.1.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.texne.g1.basis</groupId>
+      <groupId>com.loopermallee.moncchichi</groupId>
       <artifactId>client-service-bridge</artifactId>
       <version>1.1.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.texne.g1.basis</groupId>
+      <groupId>com.loopermallee.moncchichi</groupId>
       <artifactId>core</artifactId>
       <version>1.0.1</version>
       <scope>runtime</scope>

--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <permission android:name="io.texne.g1.basis.permission.CONNECT_TO_SERVICE" />
+    <permission android:name="com.loopermallee.moncchichi.permission.CONNECT_TO_SERVICE" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
@@ -16,15 +16,15 @@
             android:enabled="true" />
 
         <service
-            android:name="io.texne.g1.basis.service.G1Service"
+            android:name="com.loopermallee.moncchichi.service.G1Service"
             android:foregroundServiceType="connectedDevice"
-            android:permission="io.texne.g1.basis.permission.CONNECT_TO_SERVICE"
+            android:permission="com.loopermallee.moncchichi.permission.CONNECT_TO_SERVICE"
             android:stopWithTask="false"
             android:exported="true"
             tools:ignore="ExportedService">
             <intent-filter>
-                <action android:name="io.texne.g1.basis.service.protocol.IG1Service" />
-                <action android:name="io.texne.g1.basis.service.protocol.IG1ServiceClient" />
+                <action android:name="com.loopermallee.moncchichi.service.protocol.IG1Service" />
+                <action android:name="com.loopermallee.moncchichi.service.protocol.IG1ServiceClient" />
             </intent-filter>
         </service>
     </application>

--- a/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1Service.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.service
+package com.loopermallee.moncchichi.service
 
 import android.Manifest
 import android.app.Notification
@@ -22,13 +22,13 @@ import com.loopermallee.moncchichi.bluetooth.BluetoothManager
 import com.loopermallee.moncchichi.bluetooth.DeviceManager
 import com.nabinbhandari.android.permissions.PermissionHandler
 import com.nabinbhandari.android.permissions.Permissions
-import io.texne.g1.basis.service.protocol.G1Glasses
-import io.texne.g1.basis.service.protocol.G1ServiceState
-import io.texne.g1.basis.service.protocol.IG1Service
-import io.texne.g1.basis.service.protocol.IG1StateCallback
-import io.texne.g1.basis.service.protocol.IG1ServiceClient
-import io.texne.g1.basis.service.protocol.ObserveStateCallback
-import io.texne.g1.basis.service.protocol.OperationCallback
+import com.loopermallee.moncchichi.service.protocol.G1Glasses
+import com.loopermallee.moncchichi.service.protocol.G1ServiceState
+import com.loopermallee.moncchichi.service.protocol.IG1Service
+import com.loopermallee.moncchichi.service.protocol.IG1StateCallback
+import com.loopermallee.moncchichi.service.protocol.IG1ServiceClient
+import com.loopermallee.moncchichi.service.protocol.ObserveStateCallback
+import com.loopermallee.moncchichi.service.protocol.OperationCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -210,8 +210,8 @@ class G1Service : Service() {
             applicationContext.startService(Intent(applicationContext, G1Service::class.java))
         }
         return when (intent?.action) {
-            "io.texne.g1.basis.service.protocol.IG1Service" -> binder
-            "io.texne.g1.basis.service.protocol.IG1ServiceClient" -> clientBinder
+            "com.loopermallee.moncchichi.service.protocol.IG1Service" -> binder
+            "com.loopermallee.moncchichi.service.protocol.IG1ServiceClient" -> clientBinder
             else -> null
         }
     }

--- a/service/src/main/java/io/texne/g1/basis/service/G1ServiceImpl.kt
+++ b/service/src/main/java/io/texne/g1/basis/service/G1ServiceImpl.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.basis.service
+package com.loopermallee.moncchichi.service
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothGatt
@@ -10,10 +10,10 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.os.ParcelUuid
 import android.util.Log
-import io.texne.g1.basis.service.protocol.IG1Service
-import io.texne.g1.basis.service.protocol.IG1StateCallback
-import io.texne.g1.basis.service.protocol.G1ServiceState
-import io.texne.g1.basis.service.protocol.OperationCallback
+import com.loopermallee.moncchichi.service.protocol.IG1Service
+import com.loopermallee.moncchichi.service.protocol.IG1StateCallback
+import com.loopermallee.moncchichi.service.protocol.G1ServiceState
+import com.loopermallee.moncchichi.service.protocol.OperationCallback
 import java.util.UUID
 
 class G1ServiceImpl : IG1Service.Stub() {

--- a/subtitles/build.gradle.kts
+++ b/subtitles/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    namespace = "io.texne.g1.subtitles"
+    namespace = "com.loopermallee.moncchichi"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "io.texne.g1.subtitles"
+        applicationId = "com.loopermallee.moncchichi"
         minSdk = 24
         targetSdk = 35
         versionCode = 1

--- a/subtitles/src/main/AndroidManifest.xml
+++ b/subtitles/src/main/AndroidManifest.xml
@@ -13,18 +13,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:name=".SubtitlesApplication"
+        android:name="com.loopermallee.moncchichi.subtitles.SubtitlesApplication"
         android:theme="@style/Theme.Subtitles"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
-            android:exported="true"
-            android:theme="@style/Theme.Subtitles">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:name="com.loopermallee.moncchichi.subtitles.MainActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Subtitles"/>
     </application>
 
 </manifest>

--- a/subtitles/src/main/java/io/texne/g1/subtitles/MainActivity.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/MainActivity.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles
+package com.loopermallee.moncchichi.subtitles
 
 import android.Manifest
 import android.os.Bundle
@@ -14,10 +14,10 @@ import androidx.lifecycle.lifecycleScope
 import com.nabinbhandari.android.permissions.PermissionHandler
 import com.nabinbhandari.android.permissions.Permissions
 import dagger.hilt.android.AndroidEntryPoint
-import io.texne.g1.basis.client.G1ServiceClient
-import io.texne.g1.subtitles.model.Repository
-import io.texne.g1.subtitles.ui.SubtitlesScreen
-import io.texne.g1.subtitles.ui.theme.SubtitlesTheme
+import com.loopermallee.moncchichi.client.G1ServiceClient
+import com.loopermallee.moncchichi.subtitles.model.Repository
+import com.loopermallee.moncchichi.subtitles.ui.SubtitlesScreen
+import com.loopermallee.moncchichi.subtitles.ui.theme.SubtitlesTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/subtitles/src/main/java/io/texne/g1/subtitles/SubtitlesApplication.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/SubtitlesApplication.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles
+package com.loopermallee.moncchichi.subtitles
 
 import android.app.Application
 import dagger.Module

--- a/subtitles/src/main/java/io/texne/g1/subtitles/model/Recognizer.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/model/Recognizer.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles.model
+package com.loopermallee.moncchichi.subtitles.model
 
 import android.content.Context
 import android.content.Intent

--- a/subtitles/src/main/java/io/texne/g1/subtitles/model/Repository.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/model/Repository.kt
@@ -1,11 +1,11 @@
-package io.texne.g1.subtitles.model
+package com.loopermallee.moncchichi.subtitles.model
 
 import android.content.Context
 import android.util.Log
 import android.content.pm.PackageManager
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.texne.g1.basis.client.G1ServiceClient
-import io.texne.g1.basis.client.G1ServiceCommon
+import com.loopermallee.moncchichi.client.G1ServiceClient
+import com.loopermallee.moncchichi.client.G1ServiceCommon
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -41,7 +41,7 @@ class Repository @Inject constructor(
     init {
         writableState.value = State(
             hubInstalled = try {
-                applicationContext.packageManager.getPackageInfo("io.texne.g1.hub", 0)
+                applicationContext.packageManager.getPackageInfo("com.loopermallee.moncchichi", 0)
                 true
             } catch (e: PackageManager.NameNotFoundException) {
                 false

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesScreen.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles.ui
+package com.loopermallee.moncchichi.subtitles.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -32,8 +32,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.subtitles.R
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.subtitles.R
 
 @Composable
 fun SubtitlesScreen(

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesViewModel.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/SubtitlesViewModel.kt
@@ -1,11 +1,11 @@
-package io.texne.g1.subtitles.ui
+package com.loopermallee.moncchichi.subtitles.ui
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.texne.g1.basis.client.G1ServiceCommon
-import io.texne.g1.subtitles.model.Repository
+import com.loopermallee.moncchichi.client.G1ServiceCommon
+import com.loopermallee.moncchichi.subtitles.model.Repository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Color.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles.ui.theme
+package com.loopermallee.moncchichi.subtitles.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Theme.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles.ui.theme
+package com.loopermallee.moncchichi.subtitles.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Type.kt
+++ b/subtitles/src/main/java/io/texne/g1/subtitles/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package io.texne.g1.subtitles.ui.theme
+package com.loopermallee.moncchichi.subtitles.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle


### PR DESCRIPTION
## Summary
- add a Kotlin script to audit AndroidManifest files and ignore generated build folders
- standardise namespaces, Maven coordinates, and manifest declarations to `com.loopermallee.moncchichi`
- migrate client/service/AIDL code to the new package, remove duplicate launchers, and wire a CrashProbe `Application`

## Testing
- `./gradlew clean`
- `./gradlew assembleDebug --no-build-cache --stacktrace` *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fe1d20c08332baa74d89a96e0a52